### PR TITLE
Save slack posts into the database 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ group :development, :test do
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
   gem 'rspec-rails'
   gem 'dotenv-rails'
+  gem 'pry'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,8 @@ gem "redis"
 gem 'slack-ruby-bot-server'
 gem 'slack-ruby-bot-server-events'
 
+gem 'interactor'
+
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"
 

--- a/Gemfile
+++ b/Gemfile
@@ -57,8 +57,11 @@ group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
   gem 'rspec-rails'
+  gem 'rspec-its'
   gem 'dotenv-rails'
   gem 'pry'
+  gem 'webmock'
+  gem 'super_diff'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,7 @@ GEM
     importmap-rails (1.0.2)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
+    interactor (3.1.2)
     io-console (0.5.11)
     io-wait (0.2.1)
     irb (1.4.1)
@@ -333,6 +334,7 @@ DEPENDENCIES
   debug
   dotenv-rails
   importmap-rails
+  interactor
   jbuilder
   pg
   pry

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,10 +66,13 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
     async (1.30.1)
       console (~> 1.10)
       nio4r (~> 2.3)
       timers (~> 4.1)
+    attr_extras (6.2.5)
     bindex (0.8.1)
     bootsnap (1.10.3)
       msgpack (~> 1.2)
@@ -78,6 +81,8 @@ GEM
     concurrent-ruby (1.1.9)
     console (1.14.0)
       fiber-local
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     debug (1.4.0)
       irb (>= 1.3.6)
@@ -151,6 +156,7 @@ GEM
       roar (~> 1.1.0)
     grape-swagger (1.4.2)
       grape (~> 1.3)
+    hashdiff (1.0.1)
     hashie (5.0.0)
     i18n (1.9.1)
       concurrent-ruby (~> 1.0)
@@ -205,10 +211,14 @@ GEM
       racc (~> 1.4)
     nokogiri (1.13.1-x86_64-linux)
       racc (~> 1.4)
+    optimist (3.0.1)
+    patience_diff (1.2.0)
+      optimist (~> 3.0)
     pg (1.3.2)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    public_suffix (4.0.6)
     puma (5.6.2)
       nio4r (~> 2.0)
     racc (1.6.0)
@@ -256,6 +266,7 @@ GEM
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
+    rexml (3.2.5)
     roar (1.1.1)
       representable (~> 3.0)
     rspec-core (3.11.0)
@@ -263,6 +274,9 @@ GEM
     rspec-expectations (3.11.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
+    rspec-its (1.3.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
     rspec-mocks (3.11.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
@@ -305,6 +319,10 @@ GEM
     stimulus-rails (1.0.2)
       railties (>= 6.0.0)
     strscan (3.0.1)
+    super_diff (0.8.0)
+      attr_extras (>= 6.2.4)
+      diff-lcs
+      patience_diff
     thor (1.2.1)
     timeout (0.2.0)
     timers (4.3.3)
@@ -320,6 +338,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.14.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -341,14 +363,17 @@ DEPENDENCIES
   puma
   rails
   redis
+  rspec-its
   rspec-rails
   slack-ruby-bot-server
   slack-ruby-bot-server-events
   sprockets-rails
   stimulus-rails
+  super_diff
   turbo-rails
   tzinfo-data
   web-console
+  webmock
 
 RUBY VERSION
    ruby 3.0.3p157

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
     bootsnap (1.10.3)
       msgpack (~> 1.2)
     builder (3.2.4)
+    coderay (1.1.3)
     concurrent-ruby (1.1.9)
     console (1.14.0)
       fiber-local
@@ -204,6 +205,9 @@ GEM
     nokogiri (1.13.1-x86_64-linux)
       racc (~> 1.4)
     pg (1.3.2)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     puma (5.6.2)
       nio4r (~> 2.0)
     racc (1.6.0)
@@ -331,6 +335,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   pg
+  pry
   puma
   rails
   redis

--- a/app/interactors/application_interactor.rb
+++ b/app/interactors/application_interactor.rb
@@ -1,0 +1,3 @@
+class ApplicationInteractor
+  include Interactor
+end

--- a/app/interactors/slack_event/create_new_post.rb
+++ b/app/interactors/slack_event/create_new_post.rb
@@ -1,0 +1,32 @@
+class SlackEvent::CreateNewPost < ApplicationInteractor
+  def call
+    SlackPost.create(new_post_attributes) if new_message?
+  end
+
+  private
+
+  def new_post_attributes
+    {
+      external_id: data['event_id'],
+      team_id: data['team_id'],
+      user_id: data['event']['user'],
+      channel_id: data['event']['channel'],
+      timestamp: timestamp_to_datetime,
+      text: data['event']['text'],
+      exposed: false,
+    }
+  end
+
+  def data
+    context.event
+  end
+
+  def timestamp_to_datetime
+    ts = data['event']['ts']
+    Time.zone.at(ts.to_f)
+  end
+
+  def new_message?
+    data['event'] && data['event']['type'] == 'message'
+  end
+end

--- a/app/models/slack_post.rb
+++ b/app/models/slack_post.rb
@@ -1,0 +1,2 @@
+class SlackPost < ApplicationRecord
+end

--- a/db/migrate/20220306144302_create_slack_posts.rb
+++ b/db/migrate/20220306144302_create_slack_posts.rb
@@ -1,0 +1,14 @@
+class CreateSlackPosts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :slack_posts do |t|
+      t.string :external_id
+      t.string :team_id
+      t.string :user_id
+      t.string :channel_id
+      t.datetime :timestamp
+      t.text :text
+      t.boolean :exposed, default: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,44 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 2022_03_06_144302) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "slack_posts", force: :cascade do |t|
+    t.string "external_id"
+    t.string "team_id"
+    t.string "user_id"
+    t.string "channel_id"
+    t.datetime "timestamp"
+    t.text "text"
+    t.boolean "exposed", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "teams", force: :cascade do |t|
+    t.string "team_id"
+    t.string "name"
+    t.string "domain"
+    t.string "token"
+    t.string "oauth_scope"
+    t.string "oauth_version", default: "v1", null: false
+    t.string "bot_user_id"
+    t.string "activated_user_id"
+    t.string "activated_user_access_token"
+    t.boolean "active", default: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/spec/api/slack/api_spec.rb
+++ b/spec/api/slack/api_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+describe 'Slack API Events handler', type: :request do
+  subject(:post_event!) { post '/api/slack/event', params: event }
+
+  context 'without checking the signature' do
+    before { allow_any_instance_of(Slack::Events::Request).to receive(:verify!) }
+
+    context 'when a new text message has been post in Slack' do
+      let(:event) do
+        {
+          token: 'jd0Vwuywb5ioVAg6cHt1FtZI',
+          team_id: 'T032U7M6ZGT',
+          api_app_id: 'A19GAJ72T',
+          event: {
+            client_msg_id: '2280316d-b9fe-456b-b30f-39f733d3d702',
+            type: 'message',
+            user: 'U032U764VTL',
+            text: 'yo lol',
+            channel: 'C032DJSD355',
+            event_ts: '1547842100.001400',
+            ts: '1646566293.383579'
+          },
+          type: 'event_callback',
+          event_id: 'EvFGTNRKLG',
+          event_time: 1646566293,
+        }
+      end
+      let(:new_post) { SlackPost.first }
+
+      it 'saves the post in the database' do
+        post_event!
+
+        expect(new_post).to have_attributes({
+          external_id: 'EvFGTNRKLG',
+          team_id: 'T032U7M6ZGT',
+          user_id: 'U032U764VTL',
+          channel_id: 'C032DJSD355',
+          text: 'yo lol',
+          exposed: false,
+        })
+        expect(new_post.timestamp.to_s).to eq('2022-03-06 11:31:33 UTC')
+      end
+
+      it 'saves the post as non exposed yet' do
+        post_event!
+
+        expect(new_post.exposed?).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/interactors/slack_event/create_new_post_spec.rb
+++ b/spec/interactors/slack_event/create_new_post_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+describe SlackEvent::CreateNewPost do
+  subject { described_class.call(event: event) }
+
+  context 'when incoming event is a message' do
+    let(:ts) { Time.zone.now }
+    let(:slack_post) { SlackPost.first }
+
+    let(:event) do
+      {
+        'team_id' => 'T032U7M6ZGT',
+        'event' => {
+          'type' => 'message',
+          'user' => 'U032U764VTL',
+          'text' => 'yo lol',
+          'channel' => 'C032DJSD355',
+          'ts' => ts.to_f
+        },
+        'event_id' => 'EvFGTNRKLG',
+      }
+    end
+
+    it { is_expected.to be_a_success }
+
+    it 'saves the new slack post' do
+      subject
+
+      expect(slack_post).to have_attributes({
+        external_id: 'EvFGTNRKLG',
+        team_id: 'T032U7M6ZGT',
+        user_id: 'U032U764VTL',
+        channel_id: 'C032DJSD355',
+        text: 'yo lol',
+        exposed: false,
+      })
+    end
+
+    it 'sets the message timestamp' do
+      subject
+
+      expect(slack_post.timestamp.to_s).to eq(ts.to_s)
+    end
+
+    it 'sets the exposed? post attribute to false' do
+      subject
+
+      expect(slack_post.exposed).to eq(false)
+    end
+  end
+
+  context 'when incoming event is not a message' do
+    let(:event) do
+      {
+        'team_id' => 'T032U7M6ZGT',
+        'event' => {
+          'type' => 'not_a_message',
+          'user' => 'U032U764VTL',
+        },
+        'event_id' => 'EvFGTNRKLG',
+      }
+    end
+
+    it { is_expected.to be_a_success }
+
+    it 'does not save anything in the database' do
+      expect { subject }.not_to change(SlackPost, :count)
+    end
+  end
+end

--- a/spec/models/slack_post_spec.rb
+++ b/spec/models/slack_post_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SlackPost, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ require_relative '../config/environment'
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
+require "super_diff/rspec-rails"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,9 @@
 # it.
 #
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+require 'webmock/rspec'
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
Listen to Slack Events API and store every new messages that are posted on Slack. 

Closes #4 